### PR TITLE
Solved error "KeyError: 'ng-init'"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ into folders according to tags. You can also submit it using command line.
 ## Installation
 ---------------
 Requirements:
-1. Anaconda (recommended) or other python environments
+1. Anaconda (recommended, required in most raw linux distros) or other python environments
 2. pip install BeautifulSoup
 
 Install:

--- a/lctool/func.py
+++ b/lctool/func.py
@@ -59,8 +59,11 @@ class lctool:
         url = self.baseurl + '/problems/' + problem
         f = urllib.urlopen(url)
         soup = BeautifulSoup(f)
-        mydiv = soup.findAll("div", { "class" : "container" }).pop()
-        codes = mydiv.attrMap['ng-init']
+        mydivs = soup.findAll("div", { "class" : "container" })
+        codes = []
+        for div in mydivs:
+            if 'ng-init' in div.attrMap:
+                codes = div.attrMap['ng-init']
         qid = int(codes.split('[{')[1].split('},],')[1].split(',')[1])
         codesj = ("{%s}" % codes.split('[{')[1].split('},],')[0]).split('},{')
         res = ''


### PR DESCRIPTION
Solve error with message:

```
Traceback (most recent call last):
  File "/usr/local/bin/lc-get", line 9, in 
    loadentrypoint('lctool==0.1.0.dev0', 'consolescripts', 'lc-get')()
  File "build/bdist.linux-x8664/egg/lctool/run.py", line 37, in lcget
  File "build/bdist.linux-x8664/egg/lctool/func.py", line 63, in getproblem_source
KeyError: 'ng-init'
```
